### PR TITLE
V0 final push

### DIFF
--- a/constants/aws/locationMappings.js
+++ b/constants/aws/locationMappings.js
@@ -1,6 +1,6 @@
-module.exports.LOCATION_TO_TEST_RUNNER = {
+module.exports.LOCATION_TO_PRE_PROCESSOR = {
   'pre-processing': {
-    arn: 'arn:aws:lambda:us-east-1:082057163641:function:testRunnerV0',
-    title: 'testRunnerV0',
+    arn: 'arn:aws:lambda:us-east-1:082057163641:function:preProcessor-home',
+    title: 'preProcessor-home',
   },
 };

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -15,7 +15,7 @@ const createEventBridgeRule = async (test) => {
       ruleName,
       lambdaArn: LOCATION_TO_PRE_PROCESSOR['pre-processing'].arn,
       lambdaName: LOCATION_TO_PRE_PROCESSOR['pre-processing'].title,
-      inputJSON: JSON.stringify(test.httpRequest),
+      inputJSON: JSON.stringify(test),
     });
 
     try {

--- a/controllers/testsController.js
+++ b/controllers/testsController.js
@@ -1,4 +1,4 @@
-const { LOCATION_TO_TEST_RUNNER } = require('../constants/aws/locationMappings');
+const { LOCATION_TO_PRE_PROCESSOR } = require('../constants/aws/locationMappings');
 const { createRule, addTargetLambda } = require('../lib/aws/eventBridgeActions');
 const { addNewTest } = require('../lib/db/query');
 
@@ -13,8 +13,8 @@ const createEventBridgeRule = async (test) => {
 
     targetResponse = await addTargetLambda({
       ruleName,
-      lambdaArn: LOCATION_TO_TEST_RUNNER['pre-processing'].arn,
-      lambdaName: LOCATION_TO_TEST_RUNNER['pre-processing'].title,
+      lambdaArn: LOCATION_TO_PRE_PROCESSOR['pre-processing'].arn,
+      lambdaName: LOCATION_TO_PRE_PROCESSOR['pre-processing'].title,
       inputJSON: JSON.stringify(test.httpRequest),
     });
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,3 +70,7 @@ The new test is returned in JSON format with a 201 response status code.
 ```text
 Test my-new-test created
 ```
+
+#### 1.1.3 Forwarded Payload
+
+The payload received from the client (refer to 1.1.1) is forwarded to EventBridge for use as the "Input to Target" JSON without modification.


### PR DESCRIPTION
This PR includes the following changes:

- EB rules for newly created tests are pointed to the target lambda `preProcessor-home` 
- Modified JSON forwarded to EventBridge to include test title/ conform to spec
- updated API docs (section 1.1.3 Forwarded Payload) to explicitly state the JSON received from the client is what is being forwarded to EventBridge

Example of newly created rule in EventBridge:
![Screen Shot 2022-07-13 at 12 33 27 PM](https://user-images.githubusercontent.com/72320460/178806135-c183337e-2bbb-4996-8ea9-a82e0d0305b9.jpg)

Input to Target Constant for above rule:
![Screen Shot 2022-07-13 at 12 33 56 PM](https://user-images.githubusercontent.com/72320460/178806240-eeb29408-9afb-4052-802a-e8a91a155f07.jpg)

